### PR TITLE
Keychip: add A700X short data sheet

### DIFF
--- a/02-keychip/pcb.md
+++ b/02-keychip/pcb.md
@@ -2,7 +2,7 @@
 
 ## Components
 * [Winbond 25X40CLS1G SPI Memory](https://www.winbond.com/resource-files/w25x40cl_f%2020140325.pdf)
-* NXP 7001C Secure Processor
+* [NXP A7001C Secure Processor](https://radioaktiv.ru/ds/nxp/A700X_FAM_SDS.pdf)
 * [NXP LPC11U14F ARM Processor](https://www.nxp.com/docs/en/data-sheet/LPC11U1X.pdf)
 ## Images
 


### PR DESCRIPTION
The full data sheet is under a NDA. I could not find it on the Internet.

There are more recent versions of this preliminary short data sheet, but the one
linked here is the one with the most information. Version 3.1 (which appears to
be the most recent) removed the chapter about pinning information.

If your end goal is to emulate a keychip, you will need the master RSA key that is (presumably) stored in every A700X.
I assume the secure elements are vulnerable to this : https://ninjalab.io/a-side-journey-to-titan/